### PR TITLE
v0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![NPM Version](http://img.shields.io/npm/v/altnode.cross-fade-node.svg?style=flat-square)](https://www.npmjs.org/package/altnode.cross-fade-node)
 [![License](http://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](http://mohayonao.mit-license.org/)
 
+![graph](https://github.com/altnode/cross-fade-node/wiki/images/cross-fade-node.png)
+
 ## Installation
 
 ```

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "altnode.cross-fade-node",
   "description": "altnode.CrossFadeNode",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "author": "Nao Yonamine <mohayonao@gmail.com>",
   "bugs": {
     "url": "https://github.com/altnode/cross-fade-node/issues"

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "url": "https://github.com/altnode/cross-fade-node/issues"
   },
   "dependencies": {
-    "altnode.audio-node": "^0.1.1",
-    "altnode.dc-node": "^0.1.0"
+    "altnode.alt-audio-node": "^0.2.0",
+    "altnode.dc-node": "^0.2.0"
   },
   "devDependencies": {
     "babel": "^5.8.23",

--- a/src/CrossFadeNode.js
+++ b/src/CrossFadeNode.js
@@ -1,11 +1,11 @@
-import AudioNode from "altnode.audio-node";
+import AltAudioNode from "altnode.alt-audio-node";
 import DCNode from "altnode.dc-node";
 import CrossFadeCurves from "./CrossFadeCurves";
 import createZeroGain from "./createZeroGain";
 import createWaveShaper from "./createWaveShaper";
 import { INLETS, WAVESHAPERS, FADE, DC } from "./symbols";
 
-export default class CrossFadeNode extends AudioNode {
+export default class CrossFadeNode extends AltAudioNode {
   constructor(audioContext, curveType) {
     super(audioContext);
 


### PR DESCRIPTION
- use `altnode.AltAudioNode` instead of `altnode.AudioNode`
